### PR TITLE
Fix some BCR presubmit issues.

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -21,7 +21,13 @@ tasks:
       - "--copt=-funsigned-char"
       - "--host_copt=-funsigned-char"
     build_targets:
-      - "@gloop//..."
+      - "@gloop//gloop/concurrent/rcu:view"
+      - "@gloop//gloop/thread"
+      - "@gloop//gloop/thread/fiber"
+      - "@gloop//gloop/util/status"
+      - "@gloop//gloop/util/task"
+      - "@gloop//gloop/util/hash"
+      - "@gloop//gloop/util/symbolize"
 
 bcr_test_module:
   module_path: "gloop/examples"

--- a/gloop/examples/MODULE.bazel
+++ b/gloop/examples/MODULE.bazel
@@ -11,5 +11,5 @@ bazel_dep(name = "rules_cc", version = "0.2.18")
 
 local_path_override(
     module_name = "gloop",
-    path = "..",
+    path = "../..",
 )


### PR DESCRIPTION
- We can't actually build tests because dev dependencies aren't available
- Our examples were failing to build because of a bad relative path to the gloop repo

PiperOrigin-RevId: 972671545